### PR TITLE
Cleanup README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@
 
 A PHP REST server for providing a very light-weight REST API. Very easy to set up and get going. Independent from other libraries and frameworks. Supports HTTP authentication. Supports AMF data if the Zend Framework is present for Flash clients.
 
-As of [Classification of HTTP-based APIs](http://www.nordsc.com/ext/classification_of_http_based_apis.html) this implementation should be considered as an HTTP based type II type of an API. So it is not an academic version of a real RESTful API, but this is by intention, so it's easy to understand and install.
+As of [Classification of HTTP-based APIs](https://algermissen.io/classification_of_http_apis.html) this implementation should be considered as an HTTP based type II type of an API. So it is not an academic version of a real RESTful API, but this is by intention, so it's easy to understand and install.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Latest Stable Version](https://poser.pugx.org/jk/restserver/v/stable.svg)](https://packagist.org/packages/jk/restserver)
 [![License](https://poser.pugx.org/jk/restserver/license.svg)](https://packagist.org/packages/jk/restserver)
 [![Total Downloads](https://poser.pugx.org/jk/restserver/downloads.svg)](https://packagist.org/packages/jk/restserver)
-[![Dependency Status](https://www.versioneye.com/php/jk:restserver/badge.svg)](https://www.versioneye.com/php/jk:restserver/)
 [![SensioLabsInsight](https://insight.sensiolabs.com/projects/efa0c47d-3ffa-4fc8-b456-18d2edd29851/mini.png)](https://insight.sensiolabs.com/projects/efa0c47d-3ffa-4fc8-b456-18d2edd29851) 
 [![Documentation Status](https://readthedocs.org/projects/restserver/badge/?version=develop)](https://readthedocs.org/projects/restserver/?badge=develop)
 


### PR DESCRIPTION
Removes versioneye-badge. vesioneye doenst exist anymore. 
Do you know https://snyk.io/?

The content behind `Classification of HTTP-based APIs` has moved. I just fixed this broken link, too.

Scrutinizer fails because of an invalid access token. Propably an easy-fix,